### PR TITLE
Correct POST URL

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -29,7 +29,7 @@ kramdown:
 
 staticman:
   #api: "https://api.staticman.net/v3/entry/github/slowbreathing/slowbreathing/master/comments"
-  api: "https://staticman3.herokuapp.com/v3/entry/github/slowbreathing/slowbreathing/master/"
+  api: "https://staticman3.herokuapp.com/v3/entry/github/slowbreathing/slowbreathing/master/comments"
   path: "_data/comments/test-slug"
 
 plugins:


### PR DESCRIPTION
See eduardoboucas/staticman#219 for info about Staticman v3 URL scheme.

![Screenshot from 2019-07-27 17-54-49](https://user-images.githubusercontent.com/5748535/61996713-aec1d680-b097-11e9-9ed1-4d65e2430a98.png)

Error screenshot while posting to your site.  In the POST URL, there's a missing `comments` at the end, which stands for the property name defined in

https://github.com/slowbreathing/slowbreathing.github.io/blob/a67b0d3670133ddacf54fcaeb81ba0badfa7b362/staticman.yml#L1-L5.

Multiple properties are permitted.  See https://github.com/sachin10101998bot/aima-exercises/blob/master/staticman.yml for example.